### PR TITLE
Using maildev as a middleware

### DIFF
--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -18,7 +18,9 @@ app.config(['$routeProvider', function($routeProvider){
 app.run(['$rootScope', function($rootScope){
   
   // Connect Socket.io
-  var socket = io();
+  var socket = io({
+    path: location.pathname + 'socket.io'
+  });
 
   socket.on('newMail', function(data) {
     $rootScope.$emit('newMail', data);

--- a/docs/api.md
+++ b/docs/api.md
@@ -27,6 +27,45 @@ maildev.getAllEmail(function(err, emails){
 });
 ```
 
+## Use Maildev as a middleware
+
+We can use maildev within an existing app by giving an additional parameter
+`middleware` to the options object. We use a proxy to redirect all maildev requests
+to the maildev app.
+
+Here is an exemple to achieve this:
+
+```javascript
+var express = require('express');
+var proxyMiddleware = require('http-proxy-middleware');
+var MailDev = require('maildev');
+var app = express();
+
+// some business with the existing app
+
+// Define a route for the middleware (path)
+var maildev = new MailDev({
+  middleware: '/maildev'
+});
+
+// Maildev available at localhost:1080/maildev
+maildev.listen(function(err) {
+  console.log('We can now sent emails to port 1025!');
+});
+
+const proxy = proxyMiddleware('/maildev', {
+  target: `http://localhost:1080`,
+  ws: true,
+});
+
+// Maildev is now available at the specified route /maildev
+app.use(proxy);
+```
+
+The maildev app will be running at `http://localhost:1080/maildev`
+but we'll be able to reach it directly from our existing webapp
+via the specified route we defined `localhost:3000/maildev`
+
 ## Relay emails
 
 MailDev can relay a given email to the given "to" address. This example will

--- a/docs/api.md
+++ b/docs/api.md
@@ -48,17 +48,18 @@ var maildev = new MailDev({
   middleware: '/maildev'
 });
 
-// Maildev available at localhost:1080/maildev
+// Maildev running on localhost:1080/maildev
 maildev.listen(function(err) {
   console.log('We can now sent emails to port 1025!');
 });
 
+// proxy all maildev requests to the maildev app
 const proxy = proxyMiddleware('/maildev', {
   target: `http://localhost:1080`,
   ws: true,
 });
 
-// Maildev is now available at the specified route /maildev
+// Maildev available at the specified route '/maildev'
 app.use(proxy);
 ```
 

--- a/index.js
+++ b/index.js
@@ -72,7 +72,7 @@ module.exports = function(config) {
 
   // Default to run on same IP as smtp
   var webIp = config.webIp ? config.webIp : config.ip;
-  web.start(config.web, webIp, mailserver, config.webUser, config.webPass);
+  web.start(config.web, webIp, mailserver, config.webUser, config.webPass, config.middleware);
 
   if (config.open){
     var open = require('open');

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -6,10 +6,11 @@ var express = require('express');
 var pkg = require('../package.json');
 
 
-module.exports = function(app, mailserver) {
+module.exports = function(app, mailserver, middleware) {
+  var router = express.Router();
 
   // Get all emails
-  app.get('/email', function(req, res){
+  router.get('/email', function(req, res){
 
     mailserver.getAllEmail(function(err, emailList){
       if (err) return res.status(404).json([]);
@@ -20,7 +21,7 @@ module.exports = function(app, mailserver) {
   });
 
   // Get single email
-  app.get('/email/:id', function(req, res){
+  router.get('/email/:id', function(req, res){
 
     mailserver.getEmail( req.params.id, function(err, email){
       if (err) return res.status(404).json({ error: err.message });
@@ -34,7 +35,7 @@ module.exports = function(app, mailserver) {
   });
 
   // Delete all emails
-  app.delete('/email/all', function(req, res){
+  router.delete('/email/all', function(req, res){
 
     mailserver.deleteAllEmail(function(err){
       if (err) return res.status(500).json({ error: err.message });
@@ -45,7 +46,7 @@ module.exports = function(app, mailserver) {
   });
 
   // Delete email by id
-  app.delete('/email/:id', function(req, res){
+  router.delete('/email/:id', function(req, res){
 
     mailserver.deleteEmail(req.params.id, function(err){
       if (err) return res.status(500).json({ error: err.message });
@@ -56,7 +57,7 @@ module.exports = function(app, mailserver) {
   });
 
   // Get Email HTML
-  app.get('/email/:id/html', function(req, res){
+  router.get('/email/:id/html', function(req, res){
 
     mailserver.getEmailHTML( req.params.id, function(err, html){
       if (err) return res.status(404).json({ error: err.message });
@@ -67,7 +68,7 @@ module.exports = function(app, mailserver) {
   });
 
   // Serve Attachments
-  app.get('/email/:id/attachment/:filename', function(req, res){
+  router.get('/email/:id/attachment/:filename', function(req, res){
 
     mailserver.getEmailAttachment(req.params.id, req.params.filename, function(err, contentType, readStream){
       if (err) return res.status(404).json('File not found');
@@ -79,7 +80,7 @@ module.exports = function(app, mailserver) {
   });
 
   // Serve email.eml
-  app.get('/email/:id/download', function(req, res){
+  router.get('/email/:id/download', function(req, res){
 
     mailserver.getEmailEml(req.params.id, function(err, contentType, filename, readStream){
       if (err) return res.status(404).json('File not found');
@@ -92,7 +93,7 @@ module.exports = function(app, mailserver) {
   });
 
   // Get email source from .eml file
-  app.get('/email/:id/source', function(req, res){
+  router.get('/email/:id/source', function(req, res){
 
     mailserver.getRawEmail( req.params.id, function(err, readStream){
 
@@ -103,7 +104,7 @@ module.exports = function(app, mailserver) {
   });
 
   // Get any config settings for display
-  app.get('/config', function(req, res){
+  router.get('/config', function(req, res){
 
     res.json({
       version:  pkg.version,
@@ -115,7 +116,7 @@ module.exports = function(app, mailserver) {
   });
 
   // Relay the email
-  app.post('/email/:id/relay', function(req, res){
+  router.post('/email/:id/relay', function(req, res){
     mailserver.getEmail(req.params.id, function(err, email){
       if (err) return res.status(404).json({ error: err.message });
 
@@ -128,4 +129,5 @@ module.exports = function(app, mailserver) {
     });
   });
 
+  app.use(middleware, router);
 };

--- a/lib/web.js
+++ b/lib/web.js
@@ -54,14 +54,15 @@ module.exports.start = function(port, host, mailserver, user, password, middlewa
     app.use(auth(user, password));
   }
 
-  app.use('/', express.static(path.join(__dirname, '../app')));
   if (middleware) {
     io.path(middleware + '/socket.io');
   } else {
     middleware = '/';
   }
 
-  routes(app, mailserver);
+  app.use(middleware, express.static(path.join(__dirname, '../app')));
+
+  routes(app, mailserver, middleware);
 
   io.attach(server);
   io.on('connection', webSocketConnection(mailserver));

--- a/lib/web.js
+++ b/lib/web.js
@@ -6,7 +6,7 @@
 var express = require('express');
 var app = express();
 var server = require('http').createServer(app);
-var io = require('socket.io').listen(server);
+var io = require('socket.io')();
 var routes = require('./routes');
 var auth = require('./auth');
 var logger = require('./logger');
@@ -48,16 +48,22 @@ function webSocketConnection(mailserver) {
  * Start the web server
  */
 
-module.exports.start = function(port, host, mailserver, user, password) {
+module.exports.start = function(port, host, mailserver, user, password, middleware) {
 
   if (user && password) {
     app.use(auth(user, password));
   }
 
   app.use('/', express.static(path.join(__dirname, '../app')));
+  if (middleware) {
+    io.path(middleware + '/socket.io');
+  } else {
+    middleware = '/';
+  }
 
   routes(app, mailserver);
 
+  io.attach(server);
   io.on('connection', webSocketConnection(mailserver));
 
   port = port || 1080;


### PR DESCRIPTION
This PR enable using Maildev as a middleware of an existing app.

The README explains how it's achieved:
```
We can use maildev within an existing app by giving an additional parameter
`middleware` to the options object. We use a proxy to redirect all maildev requests
to the maildev app.
```

Everything works fine when no middleware option is passed.

Feedbacks are welcome :)